### PR TITLE
Bump minimum PHP version to 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.3"
           - "8.4"
+          - "8.5"
         dependencies:
           - "highest"
         include:
           - dependencies: "lowest"
-            php-version: "8.3"
+            php-version: "8.4"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.3"
+          - "8.4"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/infection.yaml
+++ b/.github/workflows/infection.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "8.3"
+          php-version: "8.4"
           coverage: "pcov"
 
       - name: "Install dependencies with Composer"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.3"
+          - "8.4"
 
     steps:
       - name: "Checkout code"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "webonyx/graphql-php": "^15.4"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
This pull request updates the project to require PHP 8.4 as the minimum supported version, and adds PHP 8.5 to the test matrix.

## Key Changes
- Updated `composer.json` to require `php: ^8.4` (previously `^8.3`)
- Updated CI workflow to test against PHP 8.4 and 8.5 (removed PHP 8.3)
- Updated coding standards workflow to use PHP 8.4
- Updated static analysis workflow to use PHP 8.4
- Updated infection/mutation testing workflow to use PHP 8.4

## Details
All GitHub Actions workflows have been aligned to use PHP 8.4 as the baseline version for testing and analysis. The test matrix now includes PHP 8.5 to ensure forward compatibility with the latest PHP version.

https://claude.ai/code/session_01JpmzX6xZs1J8MDDzdgvasZ